### PR TITLE
Persist biases when saving models

### DIFF
--- a/MyMachineLearning.Tests/GenerarDatosXORTests.cs
+++ b/MyMachineLearning.Tests/GenerarDatosXORTests.cs
@@ -1,0 +1,36 @@
+using System;
+using MyMachineLearning;
+using Xunit;
+
+namespace MyMachineLearning.Tests
+{
+    public class GenerarDatosXORTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void GenerarDatosXOR_RegresaSalidasEsperadasParaTodosLosCasos(int numEntradas)
+        {
+            double[][] salidas = Program.GenerarDatosXOR(numEntradas);
+
+            int numEjemplosEsperados = 1 << numEntradas;
+            Assert.Equal(numEjemplosEsperados, salidas.Length);
+
+            for (int i = 0; i < salidas.Length; i++)
+            {
+                Assert.Single(salidas[i]);
+
+                string binario = Convert.ToString(i, 2).PadLeft(numEntradas, '0');
+                int xorEsperado = 0;
+
+                foreach (char bit in binario)
+                {
+                    xorEsperado ^= bit == '1' ? 1 : 0;
+                }
+
+                Assert.Equal(xorEsperado, salidas[i][0], 5);
+            }
+        }
+    }
+}

--- a/MyMachineLearning.Tests/MyMachineLearning.Tests.csproj
+++ b/MyMachineLearning.Tests/MyMachineLearning.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyMachineLearning\MyMachineLearning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyMachineLearning.sln
+++ b/MyMachineLearning.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyMachineLearning", "MyMachineLearning\MyMachineLearning.csproj", "{D45D16CF-208C-473C-BA9D-428E75D3D6A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyMachineLearning.Tests", "MyMachineLearning.Tests\MyMachineLearning.Tests.csproj", "{9C964041-779B-4B4A-BFCF-8B3BB659E67F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,8 +15,12 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D45D16CF-208C-473C-BA9D-428E75D3D6A1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9C964041-779B-4B4A-BFCF-8B3BB659E67F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9C964041-779B-4B4A-BFCF-8B3BB659E67F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9C964041-779B-4B4A-BFCF-8B3BB659E67F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9C964041-779B-4B4A-BFCF-8B3BB659E67F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MyMachineLearning/Neurona.cs
+++ b/MyMachineLearning/Neurona.cs
@@ -55,7 +55,7 @@ namespace MyMachineLearning
         /// Actualiza los pesos de la neurona
         /// </summary>
         /// <param name="entrada">Vector de entradas para la neurona</param>
-        /// <param name="delta">Delta de cambio en los pesos</param>
+        /// <param name="error">Error utilizado para ajustar los pesos</param>
         /// <param name="tasaAprendizaje">Tasa de aprendizaje</param>
         public void ActualizarPesos(double[] entrada, double error, double tasaAprendizaje)
         {
@@ -64,6 +64,24 @@ namespace MyMachineLearning
                 pesos[i] += tasaAprendizaje * error * entrada[i];
             }
             bias += tasaAprendizaje * error;
+        }
+
+        /// <summary>
+        /// Obtiene el sesgo (bias) actual de la neurona.
+        /// </summary>
+        /// <returns>El valor de sesgo almacenado.</returns>
+        public double ObtenerBias()
+        {
+            return bias;
+        }
+
+        /// <summary>
+        /// Establece el sesgo (bias) de la neurona.
+        /// </summary>
+        /// <param name="nuevoBias">El nuevo valor de sesgo a asignar.</param>
+        public void EstablecerBias(double nuevoBias)
+        {
+            bias = nuevoBias;
         }
     }
 }

--- a/MyMachineLearning/Program.cs
+++ b/MyMachineLearning/Program.cs
@@ -105,12 +105,9 @@ namespace MyMachineLearning
             // Timer que recoja cuanto tarda en entrenar la red
             var watch = System.Diagnostics.Stopwatch.StartNew();
 
-            // no entrenar la red si ya se ha entrenado y se ha guardado el archivo de datos de entrenamiento
-            if (!System.IO.File.Exists(path))
-            {
-                red.Entrenar(entradas, salidasEsperadas, numEpocas, tasaAprendizaje);
-            }
-            else
+            bool parametrosCargados = false;
+
+            if (System.IO.File.Exists(path))
             {
                 // leer el archivo de datos de entrenamiento
                 json = System.IO.File.ReadAllText(path);
@@ -118,12 +115,19 @@ namespace MyMachineLearning
                 // comprobar si datosEntrenadosArray es null o no tiene datos para evitar errores de ejecución en la red neuronal
                 if (datosEntrenadosArray != null && datosEntrenadosArray.Any())
                 {
-                    red.SetearPesos(datosEntrenadosArray);
+                    try
+                    {
+                        red.SetearPesos(datosEntrenadosArray);
+                        parametrosCargados = true;
+                    }
+                    catch (ArgumentException)
+                    {
+                        Console.WriteLine("No fue posible cargar los parámetros almacenados, se realizará un nuevo entrenamiento.");
+                    }
                 }
             }
 
-            // entrenar la red si no ha sido datosEntrenadosArray es null o no tiene datos
-            if (red.Entrenada() == false)
+            if (!parametrosCargados)
             {
                 red.Entrenar(entradas, salidasEsperadas, numEpocas, tasaAprendizaje);
             }
@@ -132,7 +136,7 @@ namespace MyMachineLearning
             var elapsedMs = watch.ElapsedMilliseconds;
             Console.WriteLine("Tiempo de entrenamiento: " + elapsedMs + " ms");
 
-            // crear un conjunto de resultados de datos entrenados para evitat el entrenamiento de la red cada vez que se ejecuta el programa
+            // crear un conjunto de resultados de datos entrenados para evitar el entrenamiento de la red cada vez que se ejecuta el programa
             // el archivo se encuentra en la carpeta de salida del proyecto
             var datosEntrenados = red.ObtenerPesos();
             json = JsonConvert.SerializeObject(datosEntrenados);

--- a/MyMachineLearning/Properties/AssemblyInfo.cs
+++ b/MyMachineLearning/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MyMachineLearning.Tests")]

--- a/MyMachineLearning/RedNeuronal.cs
+++ b/MyMachineLearning/RedNeuronal.cs
@@ -136,30 +136,37 @@ namespace MyMachineLearning
         /// <summary>
         /// Clase que representa una neurona de la red neuronal.
         /// </summary>        
-        internal object ObtenerPesos()
+        internal double[] ObtenerPesos()
         {
-            double[] pesos = new double[capaOculta.Length * capaOculta[0].pesos.Length + capaSalida.Length * capaSalida[0].pesos.Length];
+            int totalParametros = capaOculta.Sum(n => n.pesos.Length + 1) + capaSalida.Sum(n => n.pesos.Length + 1);
+            double[] parametros = new double[totalParametros];
             int indice = 0;
 
             foreach (Neurona neurona in capaOculta)
             {
                 foreach (double peso in neurona.pesos)
                 {
-                    pesos[indice] = peso;
+                    parametros[indice] = peso;
                     indice++;
                 }
+
+                parametros[indice] = neurona.ObtenerBias();
+                indice++;
             }
 
             foreach (Neurona neurona in capaSalida)
             {
                 foreach (double peso in neurona.pesos)
                 {
-                    pesos[indice] = peso;
+                    parametros[indice] = peso;
                     indice++;
                 }
+
+                parametros[indice] = neurona.ObtenerBias();
+                indice++;
             }
 
-            return pesos;
+            return parametros;
         }
 
         /// <summary>
@@ -168,6 +175,12 @@ namespace MyMachineLearning
         /// <param name="pesos">Un arreglo de doubles que contiene los pesos a setear.</param>
         public void SetearPesos(double[] pesos)
         {
+            int totalParametrosEsperados = capaOculta.Sum(n => n.pesos.Length + 1) + capaSalida.Sum(n => n.pesos.Length + 1);
+            if (pesos.Length != totalParametrosEsperados)
+            {
+                throw new ArgumentException("La cantidad de pesos proporcionada no coincide con la estructura de la red.", nameof(pesos));
+            }
+
             int indice = 0;
 
             foreach (Neurona neurona in capaOculta)
@@ -177,6 +190,9 @@ namespace MyMachineLearning
                     neurona.pesos[i] = pesos[indice];
                     indice++;
                 }
+
+                neurona.EstablecerBias(pesos[indice]);
+                indice++;
             }
 
             foreach (Neurona neurona in capaSalida)
@@ -186,6 +202,9 @@ namespace MyMachineLearning
                     neurona.pesos[i] = pesos[indice];
                     indice++;
                 }
+
+                neurona.EstablecerBias(pesos[indice]);
+                indice++;
             }
         }
 


### PR DESCRIPTION
## Summary
- serialize and restore neuron biases alongside weights to keep trained models consistent
- expose helpers for neuron bias access, guard parameter loading, and fall back to re-training when stored parameters are invalid
- add a test project with unit coverage for the XOR data generator and enable internal access for tests

## Testing
- `dotnet test` *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced2c7efc483219b944719d2a2aa8c